### PR TITLE
PWM Capabilities

### DIFF
--- a/src/Unosquare.WiringPi/GpioPin.Factory.cs
+++ b/src/Unosquare.WiringPi/GpioPin.Factory.cs
@@ -79,7 +79,7 @@
 
         internal static readonly Lazy<GpioPin> Pin12 = new Lazy<GpioPin>(() => new GpioPin(BcmPin.Gpio12)
         {
-            Capabilities = PinCapability.GP,
+            Capabilities = PinCapability.GP | PinCapability.PWM,
             Name = "BCM 12 (PWM0)",
         });
 
@@ -121,7 +121,7 @@
 
         internal static readonly Lazy<GpioPin> Pin19 = new Lazy<GpioPin>(() => new GpioPin(BcmPin.Gpio19)
         {
-            Capabilities = PinCapability.GP | PinCapability.SPIMISO,
+            Capabilities = PinCapability.GP | PinCapability.PWM | PinCapability.SPIMISO,
             Name = "BCM 19 (MISO)",
         });
 

--- a/src/Unosquare.WiringPi/GpioPin.cs
+++ b/src/Unosquare.WiringPi/GpioPin.cs
@@ -180,7 +180,7 @@
         }
 
         /// <summary>
-        /// Gets or sets the PWM register. Values should be between 0 and 1024.
+        /// Gets or sets the PWM register.
         /// </summary>
         /// <value>
         /// The PWM register.
@@ -201,10 +201,8 @@
                             $"Pin {BcmPinNumber} '{Name}' does not support mode '{GpioPinDriveMode.PwmOutput}'. Pin capabilities are limited to: {Capabilities}");
                     }
 
-                    var val = value.Clamp(0, 1024);
-
-                    WiringPi.PwmWrite(BcmPinNumber, val);
-                    _pwmRegister = val;
+                    WiringPi.PwmWrite(BcmPinNumber, value);
+                    _pwmRegister = value;
                 }
             }
         }


### PR DESCRIPTION
Adding PWM Capabilities to Pin BCM12 and Pin BCM 19.
Removing the limit of PwmRegister since WiringPi library supports and integer number and the MCU register supports a 32-bit number.